### PR TITLE
Add interactive mannequin shortcode plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
-# bespona
-mannequin intéractif
+# Bespona Mannequin
+
+Mini-plugin WordPress fournissant le shortcode `[bespona_mannequin]` pour afficher un mannequin interactif avec hotspots cliquables (face, poitrine, hanche, cuisse, pieds).
+
+## Installation
+
+1. Copier le dossier `bespona-mannequin` dans le répertoire `wp-content/plugins/` de votre site WordPress.
+2. Activer l'extension **Bespona Mannequin** depuis l'administration WordPress.
+3. Insérer le shortcode suivant dans vos pages ou modèles Elementor :
+
+```
+[bespona_mannequin preset="default"]
+```
+
+### Options
+
+- `preset` : nom du preset (fichier JSON situé dans `assets/presets/`). Valeur par défaut `default`.
+- `mode` : `single` (par défaut) pour une sélection exclusive ou `multi` pour autoriser plusieurs points actifs.
+
+## Snippet autonome (sans plugin)
+
+Copier les fichiers `bp-mannequin.css`, `bp-mannequin.js`, `mannequin.svg` et le dossier `presets/` (avec le JSON) dans un répertoire accessible, par exemple `/wp-content/uploads/`, puis insérer dans Elementor (widget HTML) :
+
+```html
+<link rel="stylesheet" href="/wp-content/uploads/bp-mannequin.css">
+<div class="bp-mannequin" data-preset="default">
+  <img class="bp-mannequin__img" src="/wp-content/uploads/mannequin.svg" alt="Silhouette de mannequin"/>
+  <ul class="bp-mannequin__points" aria-label="Zones du corps"></ul>
+</div>
+<script src="/wp-content/uploads/bp-mannequin.js" defer></script>
+```
+
+Le script chargera automatiquement `/wp-content/uploads/presets/default.json` et initialisera le composant.

--- a/bespona-mannequin/assets/bp-mannequin.css
+++ b/bespona-mannequin/assets/bp-mannequin.css
@@ -1,0 +1,132 @@
+.bp-mannequin {
+  position: relative;
+  width: 100%;
+  max-width: 520px;
+  margin: 0 auto;
+  font-family: inherit;
+}
+
+.bp-mannequin__img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.bp-mannequin__points {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  pointer-events: none;
+}
+
+.bp-point {
+  position: absolute;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem 0.5rem 0.5rem;
+  top: var(--bp-top, 50%);
+  left: var(--bp-left, 50%);
+  transform: translate(-50%, -50%);
+  cursor: pointer;
+  pointer-events: auto;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0);
+  min-height: 44px;
+  min-width: 44px;
+  touch-action: manipulation;
+  user-select: none;
+  transition: transform 0.2s ease, outline 0.2s ease, box-shadow 0.2s ease;
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  animation: bp-point-in 0.4s ease both;
+  animation-delay: calc(var(--bp-order, 0) * 60ms);
+}
+
+.bp-point:focus {
+  outline: none;
+}
+
+.bp-point:focus-visible {
+  box-shadow: 0 0 0 4px rgba(255, 47, 146, 0.35);
+}
+
+.bp-point:hover .bp-point__dot,
+.bp-point:focus-visible .bp-point__dot {
+  background: #ff2f92;
+}
+
+.bp-point.is-selected {
+  outline: 2px solid #ff2f92;
+  transform: translate(-50%, -50%) scale(1.05);
+}
+
+.bp-point.is-selected .bp-point__dot {
+  background: #ff2f92;
+  box-shadow: 0 0 0 4px rgba(255, 47, 146, 0.15);
+}
+
+.bp-point__dot {
+  position: relative;
+  flex: 0 0 auto;
+  width: 18px;
+  height: 18px;
+  border-radius: 9999px;
+  background: rgba(0, 0, 0, 0.7);
+  border: 2px solid #fff;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.bp-point__label {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  background: #000;
+  color: #fff;
+  border-radius: 9999px;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.2;
+  white-space: nowrap;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+}
+
+.bp-point__label::before {
+  content: "";
+  position: absolute;
+  left: -6px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 10px;
+  height: 10px;
+  background: #000;
+  clip-path: polygon(0 50%, 100% 0, 100% 100%);
+}
+
+@keyframes bp-point-in {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -40%) scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
+}
+
+@media (max-width: 600px) {
+  .bp-mannequin {
+    max-width: 480px;
+  }
+
+  .bp-point__label {
+    font-size: 0.8125rem;
+    padding: 0.35rem 0.75rem;
+  }
+}

--- a/bespona-mannequin/assets/bp-mannequin.js
+++ b/bespona-mannequin/assets/bp-mannequin.js
@@ -1,0 +1,198 @@
+(function () {
+  'use strict';
+
+  var scriptEl = document.currentScript;
+  var scriptSrc = scriptEl && scriptEl.src ? scriptEl.src.split('?')[0] : '';
+  var scriptDir = scriptSrc ? scriptSrc.replace(/\/[^/]*$/, '/') : '';
+  var settings = window.bpMannequinSettings || {};
+
+  function ensureTrailingSlash(path) {
+    if (!path) {
+      return '';
+    }
+    return path.endsWith('/') ? path : path + '/';
+  }
+
+  var assetsBase = ensureTrailingSlash(settings.assetsBaseUrl || scriptDir);
+  var presetsBase = ensureTrailingSlash(settings.presetsBaseUrl || (assetsBase + 'presets/'));
+
+  function ready(fn) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', fn, { once: true });
+    } else {
+      fn();
+    }
+  }
+
+  function warn(message) {
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('Bespona Mannequin:', message);
+    }
+  }
+
+  function resolveAssetPath(file) {
+    if (!file) {
+      return '';
+    }
+
+    if (/^([a-z]+:)?\/\//i.test(file)) {
+      return file;
+    }
+
+    return assetsBase + file.replace(/^\//, '');
+  }
+
+  function emitSelection(id, label) {
+    var detail = { id: id, label: label };
+    if (typeof console !== 'undefined' && console.info) {
+      console.info('bp_mannequin_select', detail);
+    }
+
+    if (window.dataLayer && typeof window.dataLayer.push === 'function') {
+      window.dataLayer.push({
+        event: 'bp_mannequin_select',
+        id: id,
+        label: label
+      });
+    }
+  }
+
+  function setSelected(pointEl, selected) {
+    pointEl.classList.toggle('is-selected', selected);
+    pointEl.setAttribute('aria-pressed', selected ? 'true' : 'false');
+  }
+
+  function createPoint(point, index, mode, collection) {
+    var pointEl = document.createElement('li');
+    pointEl.className = 'bp-point';
+    pointEl.setAttribute('role', 'button');
+    pointEl.setAttribute('tabindex', '0');
+    pointEl.setAttribute('aria-pressed', 'false');
+    pointEl.setAttribute('aria-label', point.label);
+    pointEl.dataset.id = point.id;
+    pointEl.dataset.label = point.label;
+    pointEl.style.setProperty('--bp-top', point.top + '%');
+    pointEl.style.setProperty('--bp-left', point.left + '%');
+    pointEl.style.setProperty('--bp-order', index);
+
+    var dotEl = document.createElement('span');
+    dotEl.className = 'bp-point__dot';
+
+    var labelEl = document.createElement('span');
+    labelEl.className = 'bp-point__label';
+    labelEl.textContent = point.label;
+
+    pointEl.appendChild(dotEl);
+    pointEl.appendChild(labelEl);
+
+    function activate() {
+      var isSelected = pointEl.classList.contains('is-selected');
+      var nextState = !isSelected;
+
+      if (mode === 'single') {
+        collection.forEach(function (item) {
+          if (item !== pointEl) {
+            setSelected(item, false);
+          }
+        });
+      }
+
+      setSelected(pointEl, nextState);
+
+      if (nextState) {
+        emitSelection(point.id, point.label);
+      }
+    }
+
+    pointEl.addEventListener('click', function (event) {
+      event.preventDefault();
+      activate();
+    });
+
+    pointEl.addEventListener('keydown', function (event) {
+      if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+        event.preventDefault();
+        activate();
+      }
+    });
+
+    return pointEl;
+  }
+
+  function initialiseContainer(container) {
+    if (!container || container.dataset.bpReady === 'true') {
+      return;
+    }
+
+    container.dataset.bpReady = 'true';
+
+    var presetName = container.getAttribute('data-preset') || 'default';
+    var mode = container.getAttribute('data-mode') === 'multi' ? 'multi' : 'single';
+    var list = container.querySelector('.bp-mannequin__points');
+    var image = container.querySelector('.bp-mannequin__img');
+
+    if (!list) {
+      warn('Aucun conteneur de points trouvé pour le mannequin.');
+      return;
+    }
+
+    var presetUrl = presetsBase + presetName + '.json';
+
+    fetch(presetUrl)
+      .then(function (response) {
+        if (!response.ok) {
+          throw new Error(response.status + ' ' + response.statusText);
+        }
+        return response.json();
+      })
+      .then(function (data) {
+        if (!data || !Array.isArray(data.points)) {
+          warn('Le preset "' + presetName + '" ne contient aucun point.');
+          return;
+        }
+
+        if (data.image && image) {
+          image.src = resolveAssetPath(data.image);
+        }
+
+        list.innerHTML = '';
+        var points = [];
+
+        data.points.forEach(function (point, index) {
+          if (typeof point.top !== 'number' || typeof point.left !== 'number') {
+            return;
+          }
+
+          var pointEl = createPoint(point, index, mode, points);
+          points.push(pointEl);
+          list.appendChild(pointEl);
+        });
+
+        container.dataset.bpMode = mode;
+      })
+      .catch(function (error) {
+        warn('Impossible de charger le preset "' + presetName + '" (' + error.message + ').');
+      });
+  }
+
+  ready(function () {
+    var containers = document.querySelectorAll('.bp-mannequin');
+    containers.forEach(initialiseContainer);
+  });
+
+  window.BesponaMannequin = window.BesponaMannequin || {};
+  window.BesponaMannequin.getSelection = function (target) {
+    var element = typeof target === 'string' ? document.querySelector(target) : target;
+
+    if (!element) {
+      return [];
+    }
+
+    return Array.prototype.slice.call(element.querySelectorAll('.bp-point.is-selected')).map(function (item) {
+      return {
+        id: item.dataset.id || '',
+        label: item.dataset.label || ''
+      };
+    });
+  };
+})();

--- a/bespona-mannequin/assets/mannequin.svg
+++ b/bespona-mannequin/assets/mannequin.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="800" viewBox="0 0 320 800" role="img" aria-labelledby="title desc">
+  <title id="title">Silhouette de mannequin</title>
+  <desc id="desc">Silhouette stylisée d'une personne, utilisée comme support pour les zones cliquables du mannequin interactif.</desc>
+  <defs>
+    <linearGradient id="bodyGradient" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#464069" />
+      <stop offset="50%" stop-color="#322d4d" />
+      <stop offset="100%" stop-color="#221f35" />
+    </linearGradient>
+    <linearGradient id="limbGradient" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#524c7a" />
+      <stop offset="100%" stop-color="#2b2644" />
+    </linearGradient>
+  </defs>
+  <g fill="url(#bodyGradient)">
+    <circle cx="160" cy="88" r="64" />
+    <path d="M160 164c-46 0-82 34-88 80L54 358c-3 22 12 42 34 45s41-12 44-34l10-70v148l-40 206c-4 22 12 44 34 48s44-12 48-34l16-98 16 98c4 22 26 36 48 32s38-26 34-48l-40-204V299l10 70c3 22 22 36 44 34s37-23 34-45l-18-114c-8-46-42-80-88-80z" />
+  </g>
+  <g fill="url(#limbGradient)">
+    <path d="M82 300c-12 0-22 9-24 21l-12 118c-3 26 16 48 42 51s48-16 51-42l6-78c1-12-8-24-21-26s-24 8-26 21l-2 26-2-36c-1-13-12-23-25-23z" />
+    <path d="M238 300c12 0 22 9 24 21l12 118c3 26-16 48-42 51s-48-16-51-42l-6-78c-1-12 8-24 21-26s24 8 26 21l2 26 2-36c1-13 12-23 25-23z" />
+    <path d="M122 616c-20 2-34 18-34 38v78c0 22 18 40 40 40s40-18 40-40v-98c0-12-11-22-23-19l-23 5z" />
+    <path d="M198 616c20 2 34 18 34 38v78c0 22-18 40-40 40s-40-18-40-40v-98c0-12 11-22 23-19l23 5z" />
+  </g>
+  <g fill="#fff" opacity="0.12">
+    <path d="M128 48c-14 6-26 16-34 30s-12 30-10 46c5-32 21-60 44-76z" />
+    <path d="M106 372c-10 30-14 64-14 98 0 8 0 16 1 24 4-54 21-103 49-146l-36 24z" />
+  </g>
+</svg>

--- a/bespona-mannequin/assets/presets/default.json
+++ b/bespona-mannequin/assets/presets/default.json
@@ -1,0 +1,10 @@
+{
+  "image": "mannequin.svg",
+  "points": [
+    { "id": "face",     "label": "Face",      "top": 8.0,  "left": 49.5 },
+    { "id": "poitrine", "label": "Poitrine",  "top": 30.0, "left": 43.0 },
+    { "id": "hanche",   "label": "Hanche",    "top": 50.0, "left": 59.0 },
+    { "id": "cuisse",   "label": "Cuisse",    "top": 65.0, "left": 46.0 },
+    { "id": "pieds",    "label": "Pieds",     "top": 95.0, "left": 50.0 }
+  ]
+}

--- a/bespona-mannequin/bespona-mannequin.php
+++ b/bespona-mannequin/bespona-mannequin.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Plugin Name: Bespona Mannequin
+ * Description: Mannequin interactif avec hotspots sélectionnables et suivi d'évènements.
+ * Version: 1.0.0
+ * Author: Bespona
+ * Text Domain: bespona-mannequin
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Register plugin assets.
+ */
+function bespona_mannequin_register_assets() {
+    $plugin_url = plugin_dir_url(__FILE__);
+    $version = '1.0.0';
+
+    wp_register_style(
+        'bp-mannequin',
+        $plugin_url . 'assets/bp-mannequin.css',
+        array(),
+        $version
+    );
+
+    wp_register_script(
+        'bp-mannequin',
+        $plugin_url . 'assets/bp-mannequin.js',
+        array(),
+        $version,
+        true
+    );
+
+    wp_localize_script(
+        'bp-mannequin',
+        'bpMannequinSettings',
+        array(
+            'assetsBaseUrl'  => trailingslashit($plugin_url . 'assets'),
+            'presetsBaseUrl' => trailingslashit($plugin_url . 'assets/presets'),
+        )
+    );
+}
+add_action('init', 'bespona_mannequin_register_assets');
+
+/**
+ * Shortcode renderer for the mannequin component.
+ *
+ * @param array $atts Shortcode attributes.
+ * @return string
+ */
+function bespona_mannequin_shortcode($atts = array()) {
+    $atts = shortcode_atts(
+        array(
+            'preset' => 'default',
+            'mode'   => 'single',
+        ),
+        $atts,
+        'bespona_mannequin'
+    );
+
+    $preset = sanitize_key($atts['preset']);
+    $mode = ('multi' === strtolower($atts['mode'])) ? 'multi' : 'single';
+
+    wp_enqueue_style('bp-mannequin');
+    wp_enqueue_script('bp-mannequin');
+
+    $image_src = plugin_dir_url(__FILE__) . 'assets/mannequin.svg';
+
+    ob_start();
+    ?>
+    <div class="bp-mannequin" data-preset="<?php echo esc_attr($preset); ?>" data-mode="<?php echo esc_attr($mode); ?>">
+        <img class="bp-mannequin__img" src="<?php echo esc_url($image_src); ?>" alt="Silhouette de mannequin" />
+        <ul class="bp-mannequin__points" aria-label="Zones du corps"></ul>
+    </div>
+    <?php
+    return trim(ob_get_clean());
+}
+add_shortcode('bespona_mannequin', 'bespona_mannequin_shortcode');


### PR DESCRIPTION
## Summary
- add WordPress mini-plugin exposing the [bespona_mannequin] shortcode and registering assets with localized base URLs
- implement responsive CSS/JS for the mannequin hotspots with accessibility, analytics logging, and optional multi-select mode
- include the default preset configuration, accessible mannequin SVG placeholder, and README guidance plus a standalone integration snippet

## Testing
- php -l bespona-mannequin/bespona-mannequin.php

------
https://chatgpt.com/codex/tasks/task_e_68d362df602c8330aee93c33e2d53bf9